### PR TITLE
Support Rails 3.2 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,9 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.2
+  - 2.1
 
-notifications:
-  email:
-    recipients:
-      - api-versions@erich.erichmenge.com
-      - me@davidcel.is
 env:
-  - RAILS_VERSION=3-0-stable
-  - RAILS_VERSION=3-1-stable
   - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION=4.0.0
-  - RAILS_VERSION=master
 
-matrix:
-  allow_failures:
-    - env: RAILS_VERSION=master

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Code Climate](https://codeclimate.com/github/erichmenge/api-versions.png)](https://codeclimate.com/github/erichmenge/api-versions)
 
 ### Requirements
-* Rails 4 or Rails 3
+* Rails 3
 * Ruby 1.9 or greater
 
 

--- a/api-versions.gemspec
+++ b/api-versions.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9'
 
-  s.add_dependency('actionpack', '>= 3.0')
-  s.add_dependency('activesupport', '>= 3.0')
+  s.add_dependency('actionpack', '~> 3.2')
+  s.add_dependency('activesupport', '~> 3.2')
 
   s.add_development_dependency "rspec-rails", "~> 2.0"
   s.add_development_dependency 'ammeter',  '0.2.5'


### PR DESCRIPTION
We only use Rails 3.2 currently and tests fail with Rails 4.
Since we're not particularly concerned about supporting Rails 4 until we're using it, punting for now.