### PR TITLE
Add tests for unversioned header

### DIFF
--- a/lib/api-versions/version.rb
+++ b/lib/api-versions/version.rb
@@ -1,6 +1,6 @@
 module ApiVersions
   MAJOR = 1
-  MINOR = 2
+  MINOR = 3
   PATCH = 0
   PRE   = nil
 

--- a/spec/routing_spec.rb
+++ b/spec/routing_spec.rb
@@ -19,6 +19,13 @@ describe 'API Routing' do
       @controller.class.should == Api::V1::BarController
     end
 
+    it "should default an unversioned header" do
+      get new_api_bar_path, nil, 'HTTP_ACCEPT' => 'application/json'
+      @controller.class.should == Api::V1::BarController
+      get new_api_foo_path, nil, 'HTTP_ACCEPT' => 'application/json'
+      response.status.should == 404
+    end
+
     it "should default with nothing after the semi-colon" do
       get new_api_bar_path, nil, 'HTTP_ACCEPT' => 'application/vnd.myvendor+json; '
       @controller.class.should == Api::V1::BarController


### PR DESCRIPTION
This covers the functionality added in 54eaadb7db90114ead688c596946ef03209d61c1 and a73cbadf1bec7d092af3801b24db69ab35f18cde.

We want this functionality (`Accept: application/json` should route to the default API version) but it isn't in the [latest tagged release of the gem](https://github.com/EDMC/api-versions/releases). This PR adds some tests for it and bumps the version which we'll tag as 1.3.0.

cc @billkauf, as I know you've had some previous experience with this gem