### PR TITLE
Support minor and prerelease API versions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+* Add support for minor versions, including minor_bump generator.
+
 ## 1.2.0
 
 * Pass `#api` options to Rails namespace          [#1, David Celis]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # api-versions
 
-[![Build Status](https://travis-ci.org/EDMC/api-versions.png?branch=master)](https://travis-ci.org/EDMC/api-versions)
-[![Gem Version](https://badge.fury.io/rb/api-versions.png)](http://badge.fury.io/rb/api-versions)
-[![Coverage Status](https://coveralls.io/repos/erichmenge/api-versions/badge.png)](https://coveralls.io/r/erichmenge/api-versions)
-[![Code Climate](https://codeclimate.com/github/erichmenge/api-versions.png)](https://codeclimate.com/github/erichmenge/api-versions)
+[![Build Status](https://travis-ci.org/PagerDuty/api-versions.png?branch=master)](https://travis-ci.org/PagerDuty/api-versions)
+[![Code Climate](https://codeclimate.com/github/PagerDuty/api-versions.png)](https://codeclimate.com/github/PagerDuty/api-versions)
 
 ### Requirements
 * Rails 3

--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ api-versions is very lightweight. It adds a generator and only one method to the
 *See below for more details on each of these topics*
 
 #### Assumptions api-versions makes:
-* You want the client to use headers to specify the API version instead of changing the URL. (`Accept` header of `application/vnd.myvendor+json;version=1` for example)
-* You specify your API version in whole integers. v1, v2, v3, etc.
-  If you need semantic versioning for an API you're likely making too many backwards incompatible changes. API versions should not change all that often.
+* You want the client to use headers to specify the API version instead of changing the URL. (`Accept` header of `application/vnd.myvendor+json;version=1.0` for example)
+* You specify your API version in major and minor versions. v1, v1.1, v2, v2.10, v3, etc.
 * Your API controllers will live under the `api/v{n}/` directory. For example `app/controllers/api/v1/authorizations_controller.rb`.
+  To meet requirements for Ruby module names, dots (`.`) in the version name are replaced by the word "dot".
 
 ## Installation
 In your Gemfile:
 
-    gem "api-versions", "~> 1.0"
+    gem "api-versions", "~> 1.4"
 
 ## Versions are specified by header, not by URL
 A lot of APIs are versioned by changing the URL. `http://test.host/api/v1/some_resource/new` for example.
 But is some_resource different from version 1 to version 2? It is likely the same resource, it is simply the interface that is changing.
 api-versions prefers the URLs stay the same. `http://test.host/api/some_resource/new` need not ever change (so long as the resource exists). The client specifies how it wants to interface with
-this resource with the `Accept` header. So if the client wants version 2 of the API, the `Accept` header might look like this: `application/vnd.myvendor+json;version=2`. A complete example is
+this resource with the `Accept` header. So if the client wants version 2 of the API, the `Accept` header might look like this: `application/vnd.myvendor+json;version=2.0`. A complete example is
 below.
 
 ## DSL ##
@@ -77,7 +77,7 @@ In your routes.rb file:
                             DELETE /api/authorizations/:id(.:format)      api/v2/authorizations#destroy
 
 
-Then the client simply sets the Accept header `application/vnd.myvendor+json;version=1`. If no version is specified, the default version you set will be assumed.
+Then the client simply sets the Accept header `application/vnd.myvendor+json;version=1.0`. If no version is specified, the default version you set will be assumed.
 You'll of course still need to copy all of your controllers over (or bump them automatically, see below), even if they haven't changed from version to version.  At least you'll remove a bit of the mess in your routes file.
 
 A more complicated example:
@@ -167,9 +167,10 @@ And finally `rake routes` outputs:
                               GET    /api/my_new_resource/:id(.:format)      api/v3/my_new_resource#show
                               PUT    /api/my_new_resource/:id(.:format)      api/v3/my_new_resource#update
                               DELETE /api/my_new_resource/:id(.:format)      api/v3/my_new_resource#destroy
-## api_versions:bump
+## `api_versions:bump` and `api_versions:minor_bump`
 The api-versions gem provides a Rails generator called `api_versions:bump`. This generator will go through all of your API controllers and find the highest version number and bump
-all controllers with it up to the next in sequence.
+all controllers with it up to the next major version in sequence.
+Another generator, called `api_versions:minor_bump`, will do the same except bump to the next minor version.
 
 If for example you have a controller `api/v1/authorizations_controller.rb` it will create `api/v2/authorizations_controller.rb` and inside:
 
@@ -221,7 +222,7 @@ require 'spec_helper'
 describe Api::V1::WidgetsController do
   describe "GET 'index'" do
     it "should be successful" do
-      get '/api/widgets', {}, 'HTTP_ACCEPT' => 'application/vnd.myvendor+json; version=1'
+      get '/api/widgets', {}, 'HTTP_ACCEPT' => 'application/vnd.myvendor+json; version=1.0'
       response.should be_success
     end
   end
@@ -236,7 +237,7 @@ require 'test_helper'
 
 class Api::V1::WidgetsControllerTest < ActionDispatch::IntegrationTest
   test "GET 'index'" do
-    get '/api/widgets', {}, 'HTTP_ACCEPT' => 'application/vnd.myvendor+json; version=1'
+    get '/api/widgets', {}, 'HTTP_ACCEPT' => 'application/vnd.myvendor+json; version=1.0'
     assert_response 200
   end
 end

--- a/lib/api-versions/dsl.rb
+++ b/lib/api-versions/dsl.rb
@@ -14,6 +14,16 @@ module ApiVersions
       def to_version_string(version)
         version.to_s.gsub(VERSION_SEPARATOR, '.')
       end
+
+      # @see Gem::Version#bump
+      def bump_minor(version)
+        segments = version.segments.dup
+        segments.pop while segments.any? { |s| String === s }
+        segments.push 0 if segments.size == 1
+
+        segments[-1] = segments[-1].succ
+        Gem::Version.new segments.join('.')
+      end
     end
 
     def initialize(context, &block)

--- a/lib/api-versions/dsl.rb
+++ b/lib/api-versions/dsl.rb
@@ -4,6 +4,18 @@ module ApiVersions
   class DSL
     extend Forwardable
 
+    VERSION_SEPARATOR = 'dot'
+
+    class << self
+      def to_version_dsl(version)
+        version.to_s.gsub('.', VERSION_SEPARATOR)
+      end
+
+      def to_version_string(version)
+        version.to_s.gsub(VERSION_SEPARATOR, '.')
+      end
+    end
+
     def initialize(context, &block)
       @context = context
       singleton_class.def_delegators :@context, *(@context.public_methods - public_methods)
@@ -14,7 +26,8 @@ module ApiVersions
       VersionCheck.default_version ||= version_number
 
       constraints VersionCheck.new(version: version_number) do
-        scope({ module: "v#{version_number}" }, &block)
+        # Valid module names are [0-9A-Za-z_] but ActionDispatch will camelize and remove underscores
+        scope({ module: "v#{self.class.to_version_dsl(version_number)}" }, &block)
       end
     end
 

--- a/lib/api-versions/version.rb
+++ b/lib/api-versions/version.rb
@@ -1,6 +1,6 @@
 module ApiVersions
   MAJOR = 1
-  MINOR = 3
+  MINOR = 4
   PATCH = 0
   PRE   = nil
 

--- a/lib/api-versions/version_check.rb
+++ b/lib/api-versions/version_check.rb
@@ -27,7 +27,11 @@ module ApiVersions
     end
 
     def unversioned?(accept_string)
-      @process_version == self.class.default_version && !(accept_string =~ version_regex)
+      @process_version == get_default_version && !(accept_string =~ version_regex)
+    end
+
+    def get_default_version
+      self.class.default_version
     end
 
     def version_regex(version_pattern = '\d')

--- a/lib/api-versions/version_check.rb
+++ b/lib/api-versions/version_check.rb
@@ -23,11 +23,15 @@ module ApiVersions
     end
 
     def matches_version?(accept_string)
-      accept_string =~ /version\s*?=\s*?#{@process_version}\b/
+      accept_string =~ version_regex(@process_version)
     end
 
     def unversioned?(accept_string)
-      @process_version == self.class.default_version && !(accept_string =~ /version\s*?=\s*?\d*\b/i)
+      @process_version == self.class.default_version && !(accept_string =~ version_regex)
+    end
+
+    def version_regex(version_pattern = '\d')
+      Regexp.new "version\\s*?=\\s*?#{version_pattern}\\b"
     end
   end
 end

--- a/lib/api-versions/version_check.rb
+++ b/lib/api-versions/version_check.rb
@@ -23,7 +23,11 @@ module ApiVersions
     end
 
     def matches_version?(accept_string)
-      accept_string =~ version_regex(@process_version)
+      process_version = Gem::Requirement.new(@process_version)
+      # Ignore anything past the minor version
+      # Versions can contain lowercase letters to indicate prerelease: http://ruby-doc.org/stdlib-2.0/libdoc/rubygems/rdoc/Gem/Version.html
+      accept_version = Gem::Version.new version_regex.match(accept_string).try(:[], :version)
+      process_version.satisfied_by? accept_version
     end
 
     def unversioned?(accept_string)
@@ -34,8 +38,8 @@ module ApiVersions
       self.class.default_version
     end
 
-    def version_regex(version_pattern = '\d')
-      Regexp.new "version\\s*?=\\s*?#{version_pattern}\\b"
+    def version_regex
+      /version\s*?=\s*?(?<version>[0-9]+(\.[0-9a-z]+)?)([^\.0-9a-z]|$)/
     end
   end
 end

--- a/lib/generators/api_versions/bump_generator.rb
+++ b/lib/generators/api_versions/bump_generator.rb
@@ -1,7 +1,7 @@
 module ApiVersions
   module Generators
     class BumpGenerator < Rails::Generators::Base
-      desc "Bump API version to next version, initializing controllers"
+      desc "Bump API version to next major version, initializing controllers"
       source_root File.expand_path('../templates', __FILE__)
 
       def get_controllers
@@ -10,15 +10,17 @@ module ApiVersions
         end
 
         @highest_version = @controllers.map do |controller|
-          controller.match(/api\/v(\d+?)\//)[1]
+          Gem::Version.new ApiVersions::DSL.to_version_string(controller.match(/api\/v(\d+?(?:dot)?\d*[a-z]?\d*)\//)[1])
         end.max
+        @highest_version_string = ApiVersions::DSL.to_version_dsl(@highest_version)
 
-        @controllers.keep_if { |element| element =~ /api\/v#{@highest_version}\// }
+        @controllers.keep_if { |element| element =~ /api\/v#{@highest_version_string}\// }
       end
 
       def generate_new_controllers
+        new_version_string = ApiVersions::DSL.to_version_dsl(@highest_version.bump)
         @controllers.each do |controller|
-          new_controller = controller.gsub(/api\/v#{@highest_version}\//, "api/v#{@highest_version.to_i + 1}/")
+          new_controller = controller.gsub(/api\/v#{@highest_version_string}\//, "api/v#{new_version_string}/")
           @current_new_controller = new_controller.chomp(File.extname(controller)).camelize
           @current_old_controller = controller.chomp(File.extname(controller)).camelize
           template 'controller.rb', File.join('app', 'controllers', new_controller)

--- a/lib/generators/api_versions/minor_bump_generator.rb
+++ b/lib/generators/api_versions/minor_bump_generator.rb
@@ -1,0 +1,31 @@
+module ApiVersions
+  module Generators
+    class MinorBumpGenerator < Rails::Generators::Base
+      desc "Bump API version to next minor version, initializing controllers"
+      source_root File.expand_path('../templates', __FILE__)
+
+      def get_controllers
+        Dir.chdir File.join(Rails.root, 'app', 'controllers') do
+          @controllers = Dir.glob('api/v**/**/*.rb')
+        end
+
+        @highest_version = @controllers.map do |controller|
+          Gem::Version.new ApiVersions::DSL.to_version_string(controller.match(/api\/v(\d+?(?:dot)?\d*[a-z]?\d*)\//)[1])
+        end.max
+        @highest_version_string = ApiVersions::DSL.to_version_dsl(@highest_version)
+
+        @controllers.keep_if { |element| element =~ /api\/v#{@highest_version_string}\// }
+      end
+
+      def generate_new_controllers
+        new_version_string = ApiVersions::DSL.to_version_dsl(ApiVersions::DSL.bump_minor(@highest_version))
+        @controllers.each do |controller|
+          new_controller = controller.gsub(/api\/v#{@highest_version_string}\//, "api/v#{new_version_string}/")
+          @current_new_controller = new_controller.chomp(File.extname(controller)).camelize
+          @current_old_controller = controller.chomp(File.extname(controller)).camelize
+          template 'controller.rb', File.join('app', 'controllers', new_controller)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v1dot1/bar_controller.rb
+++ b/spec/dummy/app/controllers/api/v1dot1/bar_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1dot1::BarController < Api::V1::BarController
+
+end

--- a/spec/dummy/app/controllers/api/v2dot0b/foo_controller.rb
+++ b/spec/dummy/app/controllers/api/v2dot0b/foo_controller.rb
@@ -1,0 +1,5 @@
+class Api::V2dot0b::FooController < ActionController::Base
+  def new
+    render nothing: true
+  end
+end

--- a/spec/dummy/app/controllers/api/v2dot0b1/foo_controller.rb
+++ b/spec/dummy/app/controllers/api/v2dot0b1/foo_controller.rb
@@ -1,0 +1,5 @@
+class Api::V2dot0b1::FooController < ActionController::Base
+  def new
+    render nothing: true
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -6,6 +6,27 @@ Dummy::Application.routes.draw do
       end
     end
 
+    version 1.1 do
+      cache as: 'v1.1' do
+        resources :bar
+        inherit from: 'v1'
+      end
+    end
+
+    version '2.0b' do
+      cache as: 'v2.0b' do
+        resources :foo
+        inherit from: 'v1'
+      end
+    end
+
+    version '2.0b1' do
+      cache as: 'v2.0b1' do
+        resources :foo
+        inherit from: 'v1'
+      end
+    end
+
     version 2 do
       cache as: 'v2' do
         resources :foo

--- a/spec/generators/minor_bump_generator_spec.rb
+++ b/spec/generators/minor_bump_generator_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'generators/api_versions/minor_bump_generator'
+
+describe ApiVersions::Generators::MinorBumpGenerator do
+  before do
+    destination File.expand_path("../../../tmp", __FILE__)
+    prepare_destination
+  end
+
+  describe "Generated files" do
+    before { run_generator }
+
+    describe "Bar Controller" do
+      subject { file('app/controllers/api/v3dot1/bar_controller.rb') }
+
+      it { should exist }
+      it { should contain /Api::V3dot1::BarController < Api::V3::BarController/ }
+    end
+
+    describe "Foo Controller" do
+      subject { file('app/controllers/api/v3dot1/foo_controller.rb') }
+
+      it { should exist }
+      it { should contain /Api::V3dot1::FooController < Api::V3::FooController/ }
+    end
+
+    describe "Nested Controller" do
+      subject { file('app/controllers/api/v3dot1/nests/nested_controller.rb') }
+
+      it { should exist }
+      it { should contain /Api::V3dot1::Nests::NestedController < Api::V3::Nests::NestedController/ }
+    end
+
+    describe "Users Controller" do
+      subject { file('app/controllers/api/v3dot1/users_controller.rb') }
+
+      it { should_not exist }
+    end
+  end
+end

--- a/spec/version_check_spec.rb
+++ b/spec/version_check_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+test_cases = {
+  valid: {
+    'with major version only' => {
+      string: 'application/vnd.myvendor+json;version=1',
+      version: 1,
+    },
+    'with major and minor version' => {
+      string: 'application/vnd.myvendor+json;version=1.0',
+      version: 1,
+    },
+    'with major and minor prerelease version' => {
+      string: 'application/vnd.myvendor+json;version=1.0b',
+      version: '1.0b',
+    },
+    'with a capital letter' => {
+      string: 'application/vnd.myvendor+json;version=1.0A',
+      version: '1.0',
+    },
+  },
+  invalid: {
+    'without version information' => 'application/vnd.myvendor+json',
+    'lacking minor version' => 'application/vnd.myvendor+json;version=1.',
+    'with multiple periods' => 'application/vnd.myvendor+json;version=1.1.',
+    'with patch version' => 'application/vnd.myvendor+json;version=1.1.1',
+  },
+  additions: [
+    ',More headers= more good',
+    ';More headers= more good',
+    '; And.then,some;things!',
+    '*More headers= more good',
+    '+More headers= more good',
+    ' additional th1ngs here',
+    ' ',
+    '$',
+    '\b',
+    "\n",
+  ],
+}
+
+describe ApiVersions::VersionCheck do
+  describe 'version_regex' do
+    subject { described_class.new.send(:version_regex) }
+
+    test_cases[:valid].each do |description, test_case|
+      it "should match an isolated string #{description}" do
+        should match(test_case[:string])
+      end
+
+      it "should match a string #{description} and appended content" do
+        test_cases[:additions].each do |addition|
+          should match("#{test_case[:string]}#{addition}")
+        end
+      end
+    end
+
+    test_cases[:invalid].each do |description, test_case|
+      it "should not match an isolated string #{description}" do
+        should_not match(test_case)
+      end
+
+      it "should not match a string #{description} and appended content" do
+        test_cases[:additions].each do |addition|
+          should_not match("#{test_case}#{addition}")
+        end
+      end
+    end
+  end
+
+  describe 'matches_version?' do
+    subject do
+      described_class.new.send(:matches_version?, test_string)
+    end
+
+    test_cases[:valid].each do |description, test_case|
+      let(:test_string) { test_case[:string] }
+
+      it "should match the version of an isolated string #{description}" do
+        instance_variable_set(:@process_version, test_case[:version])
+        should be true
+      end
+
+      context "with appended content" do
+        test_cases[:additions].each do |addition|
+          let(:test_string) { "#{test_case[:string]}#{addition}" }
+
+          it "should match the version of a string #{description}" do
+            instance_variable_set(:@process_version, test_case[:version])
+            should be true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this change, API versions can have minor versions and also prerelease specifiers ([a-z]).
Patch versions are always ignored since patches should be contributed directly to the affected minor version.

For instance, a 1.0 API endpoint lives at `Api::V1::Controller` and is accessible via any of these headers:
- `Accept: application/vnd.vendorname+json;version=1`
- `Accept: application/vnd.vendorname+json;version=1.0`
- `Accept: application/vnd.vendorname+json;version=1.0.1`

A 1.1 API endpoint lives at `Api::V1dot1::Controller` and is accessible via any of these headers:
- `Accept: application/vnd.vendorname+json;version=1.1`
- `Accept: application/vnd.vendorname+json;version=1.1.1`

A 2.0beta API endpoint lives at `Api::V2dot0b::Controller` and is accessible via:
- `Accept: application/vnd.vendorname+json;version=2.0b`

A 2.0beta1 API endpoint lives at `Api::V2dot0b1::Controller` and is accessible via:
- `Accept: application/vnd.vendorname+json;version=2.0b1`