### PR TITLE
Add ApiVersions::Versions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+* Adds `ApiVersions::Versions` to track and query all known versions.
+
 ## 1.4.0
 
 * Add support for minor versions, including minor_bump generator.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
 #### api-versions is a Gem to help you manage your Rails API endpoints.
 api-versions is very lightweight. It adds a generator and only one method to the Rails route mapper.
 
-##### It helps you in three ways:
+##### It helps you in four ways:
 
 * Provides a DSL for versioning your API in your routes file, favoring client headers vs changing the resource URLs.
 * Provides methods to cache and retrieve resources in your routes file to keep it from getting cluttered
 * Provides a generator to bump your API controllers to the next version, while inheriting the previous version.
+* Provides a mechanism to query and introspect your application's API versions.
 
 *See below for more details on each of these topics*
 

--- a/lib/api-versions.rb
+++ b/lib/api-versions.rb
@@ -1,6 +1,7 @@
 require "api-versions/version"
 require "api-versions/version_check"
 require "api-versions/dsl"
+require "api-versions/versions"
 require 'api-versions/middleware'
 require 'api-versions/railtie'
 

--- a/lib/api-versions/dsl.rb
+++ b/lib/api-versions/dsl.rb
@@ -39,6 +39,8 @@ module ApiVersions
         # Valid module names are [0-9A-Za-z_] but ActionDispatch will camelize and remove underscores
         scope({ module: "v#{self.class.to_version_dsl(version_number)}" }, &block)
       end
+
+      Versions.add_version(version_number) # Track the version
     end
 
     def inherit(options)

--- a/lib/api-versions/version.rb
+++ b/lib/api-versions/version.rb
@@ -1,7 +1,7 @@
 module ApiVersions
   MAJOR = 1
   MINOR = 4
-  PATCH = 0
+  PATCH = 1
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join '.'

--- a/lib/api-versions/versions.rb
+++ b/lib/api-versions/versions.rb
@@ -1,0 +1,35 @@
+module ApiVersions
+  class Versions
+    class << self
+      # @option options [Boolean] :prerelease (false) If true, prerelease versions are included
+      # @return [Array<String>]
+      def versions(options = {})
+        gem_versions(options).map(&:to_s)
+      end
+
+      # @option options [Boolean] :prerelease (false) If true, prerelease versions are considered
+      # @return [String]
+      def latest_version(options = {})
+        max_version = gem_versions(options).max
+        max_version = max_version.to_s unless max_version.nil?
+        max_version
+      end
+
+      def add_version(version_number)
+        @versions ||= {} # Use a hash to dedup
+        gem_version = Gem::Version.new(version_number)
+        @versions[gem_version.to_s] = gem_version
+      end
+
+      protected
+      # @option options [Boolean] :prerelease (false) If true, prerelease versions are included
+      # @return [Array<Gem::Version>]
+      def gem_versions(options = {})
+        @versions ||= {}
+        versions = @versions.values
+        versions.delete_if { |v| v.prerelease? } unless options[:prerelease]
+        versions
+      end
+    end
+  end
+end

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe 'Version Tracking' do
+  describe "versions" do
+    context "without prerelease flag" do
+      before(:each) do
+        @versions = ApiVersions::Versions.versions
+      end
+
+      it "should return only released versions" do
+        expect(@versions).not_to(include '2.0b')
+        expect(@versions).not_to(include '2.0b1')
+      end
+    end
+
+    context "with prerelease flag" do
+      before(:each) do
+        @versions = ApiVersions::Versions.versions(prerelease: true)
+      end
+
+      it "should return all versions with prerelease option" do
+        expect(@versions).to(include '1')
+        expect(@versions).to(include '1.1')
+        expect(@versions).to(include '2.0b')
+        expect(@versions).to(include '2.0b1')
+        expect(@versions).to(include '2')
+        expect(@versions).to(include '3')
+      end
+    end
+  end
+
+  describe "latest_version" do
+    context "with a new prerelease version" do
+      before(:all) do
+        ApiVersions::Versions.add_version('3.1b1')
+      end
+
+      context "without prerelease flag" do
+        before(:each) do
+          @version = ApiVersions::Versions.latest_version
+        end
+
+        it "should return the newest released version" do
+          expect(@version).to eq('3')
+        end
+      end
+
+      context "with prerelease flag" do
+        before(:each) do
+          @version = ApiVersions::Versions.latest_version(prerelease: true)
+        end
+
+        it "should return the absolute newest version" do
+          expect(@version).to eq('3.1b1')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides a mechanism to query and introspect the application's API versions. It can tell you all the API versions your application supports or the latest defined version.

- adds tests
- updates changelog
- updates README
- bumps version to 1.4.1

~~This PR is blocked by #3; I will rebase against `master` once that is merged. In the meantime, 25a70fc3df716171e56c4a1637e50218fba860b5 contains the only relevant change.~~