### PR TITLE
Add api.version header to specify version

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## 1.4.2
+
+* Adds support for internal header `api.version`
+
 ## 1.4.1
 
 * Adds `ApiVersions::Versions` to track and query all known versions.

--- a/lib/api-versions/version.rb
+++ b/lib/api-versions/version.rb
@@ -1,7 +1,7 @@
 module ApiVersions
   MAJOR = 1
   MINOR = 4
-  PATCH = 1
+  PATCH = 2
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join '.'

--- a/spec/version_check_spec.rb
+++ b/spec/version_check_spec.rb
@@ -1,6 +1,63 @@
 require 'spec_helper'
 
+ACCEPT = 'Accept'
+
 test_cases = {
+  requests: {
+    'matches accept version' => {
+      matches: true,
+      headers: {
+        ACCEPT => 'application/vnd.myvendor+json;version=1'
+      },
+      version: 1
+    },
+    'matches api.version version' => {
+      matches: true,
+      headers: {
+        ACCEPT => 'application/vnd.myvendor+json',
+        ApiVersions::VERSION_HEADER => '1.1'
+      },
+      version: 1.1
+    },
+    'matches default version' => {
+      matches: true,
+      headers: {
+        ACCEPT => 'application/vnd.myvendor+json'
+      },
+      version: 1
+    },
+    'matches api.version without vendor key present' => {
+      matches: true,
+      headers: {
+        ACCEPT => 'junk',
+        ApiVersions::VERSION_HEADER => '1'
+      },
+      version: 1
+    },
+    'api.version does not match default version' => {
+      matches: false,
+      headers: {
+        ACCEPT => 'application/vnd.myvendor+json',
+        ApiVersions::VERSION_HEADER => '1.0'
+      },
+      version: 1.1
+    },
+    'vendor version does not match default version' => {
+      matches: false,
+      headers: {
+        ACCEPT => 'application/vnd.myvendor+json;version=1',
+      },
+      version: 1.1
+    },
+    'accept not valid, vendor does not match' => {
+      matches: false,
+      headers: {
+        ACCEPT => 'junk',
+        ApiVersions::VERSION_HEADER => '1.0'
+      },
+      version: 1.1
+    },
+  },
   valid: {
     'with major version only' => {
       string: 'application/vnd.myvendor+json;version=1',
@@ -70,25 +127,45 @@ describe ApiVersions::VersionCheck do
 
   describe 'matches_version?' do
     subject do
-      described_class.new.send(:matches_version?, test_string)
+      described_class.new(version: version).send(:matches_version?, test_string)
     end
 
     test_cases[:valid].each do |description, test_case|
       let(:test_string) { test_case[:string] }
+      let(:version) { test_case[:version] }
 
       it "should match the version of an isolated string #{description}" do
-        instance_variable_set(:@process_version, test_case[:version])
         should be true
       end
 
       context "with appended content" do
         test_cases[:additions].each do |addition|
-          let(:test_string) { "#{test_case[:string]}#{addition}" }
+          context 'new addition context' do
+            let(:test_string) { "#{test_case[:string]}#{addition}" }
+            let(:version) { test_case[:version] }
 
-          it "should match the version of a string #{description}" do
-            instance_variable_set(:@process_version, test_case[:version])
-            should be true
+            it "should match the version of a string #{description}" do
+              should be true
+            end
           end
+        end
+      end
+    end
+  end
+
+  describe 'matches?' do
+    subject do
+      described_class.new(version: version).matches?(test_request)
+    end
+
+    test_cases[:requests].each do |description, test_case|
+
+      context 'with new match' do
+        let(:test_request) { OpenStruct.new(headers: test_case[:headers]) }
+        let(:version) { test_case[:version] }
+
+        it "should match the version #{description}" do
+          should be test_case[:matches]
         end
       end
     end


### PR DESCRIPTION
This change is needed to add an api version instead
of modifying existing accept headers.